### PR TITLE
Fix for line 101 compile error w/ elm-reactor 0.18.0

### DIFF
--- a/part-1/main.elm
+++ b/part-1/main.elm
@@ -98,7 +98,8 @@ divideCardString str =
 
 parseCardTuple : ( Maybe String, Maybe Char ) -> Maybe Card
 parseCardTuple ( value, suit ) =
-    case ( value `Maybe.andThen` parseValue, suit `Maybe.andThen` parseSuit ) of
+    case ( Maybe.andThen parseValue value, Maybe.andThen parseSuit suit ) of
+{--    case ( value `Maybe.andThen` parseValue, suit `Maybe.andThen` parseSuit ) of --}
         ( Just v, Just s ) ->
             Just (OrdinaryCard v s)
 


### PR DESCRIPTION
Hi,

I wasn't able to use part 1 without out changing around **line 101** to eliminate the compile error caused by `\``. Maybe this has been a change since you wrote your tutorials, but since I used your recommended `brew cask` install, I thought you might want to know.

```
    case ( value `Maybe.andThen` parseValue , `suit` Maybe.andThen parseSuit  ) of
```

to 

```
    case ( Maybe.andThen parseValue value, Maybe.andThen parseSuit suit ) of
```